### PR TITLE
feat: throw when a dependent requests a supertype of a provided type

### DIFF
--- a/GoDotDep.csproj
+++ b/GoDotDep.csproj
@@ -14,7 +14,7 @@
     <Company>Chickensoft</Company>
 
     <PackageId>Chickensoft.GoDotDep</PackageId>
-    <PackageVersion>1.2.1-beta8</PackageVersion>
+    <PackageVersion>1.3.0-beta8</PackageVersion>
     <PackageReleaseNotes>GoDotDep release.</PackageReleaseNotes>
     <PackageIcon></PackageIcon>
     <PackageTags>Godot;Dependency;Dependencies;DI;Dependency Injection;Loader;Injector;Chickensoft;Gamedev;Utility;Utilities</PackageTags>

--- a/src/DependencyExceptions.cs
+++ b/src/DependencyExceptions.cs
@@ -16,6 +16,16 @@ public class ProviderNotFoundException : InvalidOperationException {
   ) { }
 }
 
+public class DependentRequestedSupertypeException : InvalidOperationException {
+  public DependentRequestedSupertypeException(
+    Type requestedType, Type providedType
+  ) : base(
+    $"The requested dependency type `{requestedType.Name}` is a supertype " +
+    $"of the provided type `{providedType.Name}`. Please request the " +
+    $"provided type `{providedType.Name}` instead."
+  ) { }
+}
+
 /// <summary>
 /// Exception thrown if another class implements <see cref="IDependent"/> and
 /// tries to call


### PR DESCRIPTION
GoDotDep now throws if a dependent requests a supertype of a provided type. Throwing on supertypes helps prevent type collisions in the provider hierarchy and can save a game developer valuable debugging time if they accidentally request `GameState` from an `IDependent` instead of the provided `IGameState`.