### PR TITLE
fix: critical bug with dependents not resolving multi-providers

### DIFF
--- a/GoDotDep.csproj
+++ b/GoDotDep.csproj
@@ -14,7 +14,7 @@
     <Company>Chickensoft</Company>
 
     <PackageId>Chickensoft.GoDotDep</PackageId>
-    <PackageVersion>1.3.0-beta8</PackageVersion>
+    <PackageVersion>1.3.1-beta8</PackageVersion>
     <PackageReleaseNotes>GoDotDep release.</PackageReleaseNotes>
     <PackageIcon></PackageIcon>
     <PackageTags>Godot;Dependency;Dependencies;DI;Dependency Injection;Loader;Injector;Chickensoft;Gamedev;Utility;Utilities</PackageTags>

--- a/src/IDependent.cs
+++ b/src/IDependent.cs
@@ -260,7 +260,7 @@ public static class IDependentExtension {
             providedType: providedType
           );
         }
-        return providedType == genericType;
+        if (providedType == genericType) { return true; }
       }
     }
     return false;


### PR DESCRIPTION
Fixes an embarrassingly critical bug where dependents were not resolving nodes that provided multiple values.

Also adds a test case to prevent this from ever happening again.